### PR TITLE
created endpoint to set next recipe

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,9 +25,9 @@ func main() {
 	fmt.Println(appConf) // TODO: actually use this via injection to endpoint to set next recipe
 
 	recipeConf := &recipes.RecipeConfig{
-		TickerDuration: time.Hour,         // TODO: pull this from config file
-		DailyRecipe:    &recipes.Recipe{}, // TODO: update with an actual recipe
-		NextRecipe:     &recipes.Recipe{}, // TODO: to be updated via endpoint
+		TickerDuration: time.Hour,        // TODO: pull this from config file
+		DailyRecipe:    recipes.Recipe{}, // TODO: update with an actual recipe
+		NextRecipe:     recipes.Recipe{}, // TODO: to be updated via endpoint
 	}
 
 	go func() {
@@ -42,7 +42,8 @@ func main() {
 
 	srv := webserver.NewServer(
 		webserver.StaticFilesHandler(templateConf.StaticPath),
-		webserver.TemplateHandler(templateConf, recipeConf.DailyRecipe),
+		webserver.TemplateHandler(templateConf, recipeConf),
+		webserver.SetNextRecipeHandler(recipeConf),
 	)
 	httpServer := &http.Server{
 		Handler: srv,

--- a/recipes/recipes.go
+++ b/recipes/recipes.go
@@ -8,8 +8,8 @@ import (
 
 type RecipeConfig struct {
 	TickerDuration time.Duration
-	DailyRecipe    *Recipe // represents a cached version of the current day's recipe
-	NextRecipe     *Recipe // represents a cached version of the next day's recipe to be updated/displayed by the scheduler
+	DailyRecipe    Recipe // represents a cached version of the current day's recipe
+	NextRecipe     Recipe // represents a cached version of the next day's recipe to be updated/displayed by the scheduler
 }
 
 type AppConfig struct {
@@ -25,7 +25,7 @@ func (rc *RecipeConfig) ScheduleDailyRecipe(appConfig AppConfig) {
 
 	// TODO: remove after done testing
 	var err error
-	*rc.DailyRecipe, err = appConfig.Storage.GetRecipe(1)
+	rc.DailyRecipe, err = appConfig.Storage.GetRecipe(1)
 	if err != nil {
 		panic("uhoh")
 	}
@@ -42,6 +42,10 @@ func (rc *RecipeConfig) ScheduleDailyRecipe(appConfig AppConfig) {
 			}
 		}
 	}
+}
+
+func (rc *RecipeConfig) SetNextRecipe(nextRecipe Recipe) {
+	rc.NextRecipe = nextRecipe
 }
 
 // UnitLength are units of length, e.g. inches, centimeters, etc.


### PR DESCRIPTION
! Fixed future bug: previously, the index route was only accepting a pointer to a recipe. This meant any future (including this commit) endpoints that update the recipe the index route uses, would never have the correct updated recipe, as updated recipe pointer assignment is attached to the RecipeConfig struct. Now, the index route takes the *RecipeConfig, instead of the recipe itself. This will eventually be replaced once a proper method is created to get the current/daily recipe
+ Added endpoint to set the next recipe