### PR TITLE
created authentication middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,10 +45,10 @@ func main() {
 		webserver.TemplateHandler(templateConf, recipeConf),
 		webserver.SetNextRecipeHandler(recipeConf),
 	)
-	httpServer := &http.Server{
+	httpsServer := &http.Server{
 		Handler: srv,
 	}
-	if err = httpServer.ListenAndServe(); err != nil {
+	if err = httpsServer.ListenAndServeTLS("server.crt", "server.key"); err != nil {
 		log.Fatal(err) // TODO: hook up proper logging
 	}
 }

--- a/webserver/middleware.go
+++ b/webserver/middleware.go
@@ -3,10 +3,12 @@ package webserver
 import (
 	"mime"
 	"net/http"
+	"time"
 )
 
 const (
 	nonJsonContentType string = "Content-Type must be JSON"
+	unauthorized       string = "Unauthorized"
 	unknownContentType string = "Malformed Content-Type header"
 )
 
@@ -24,6 +26,57 @@ func AddMiddleware(h http.HandlerFunc, middleware ...Middleware) http.HandlerFun
 	}
 
 	return h
+}
+
+const responseWaitDuration = time.Second * 2 // TODO: pull this from config, set on conf struct
+// AuthorizeMiddleware requires being used over HTTPS connections only. It uses
+// basic authentication to check a user and password combination.  It also
+// guards against timing attacks by guaranteeing the middleware response will
+// always take the same amount of configured time.
+func AuthorizeMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, pw, ok := r.BasicAuth()
+		if !ok {
+			w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+			http.Error(w, unauthorized, http.StatusUnauthorized)
+			return
+		}
+
+		validity := make(chan bool, 1)
+		now := time.Now()
+
+		go isValidLogin(validity, user, pw)
+		// TODO (REN-145): add fingerprint whitelist check, update channel count
+
+		isValid := <-validity
+
+		elapsed := time.Since(now)
+		remaining := responseWaitDuration - elapsed
+		totalWaits := 0
+		if remaining > 0 {
+			totalWaits++
+			time.Sleep(remaining)
+		}
+
+		if totalWaits == 0 {
+			// TODO: error log this, as it means the response wait duration needs to be increased
+		}
+
+		if !isValid {
+			http.Error(w, unauthorized, http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+		return
+	}
+}
+
+// TODO: pull from storage, make this a receiver on a conf struct
+func isValidLogin(isValid chan bool, user string, password string) {
+	actualUser := "getFromStorage"
+	actualPw := "getFromStorage"
+	isValid <- (user == actualUser) && (password == actualPw)
 }
 
 // TODO: fully flesh this out later

--- a/webserver/routes.go
+++ b/webserver/routes.go
@@ -24,7 +24,7 @@ func SetNextRecipeHandler(recipeConfig *recipes.RecipeConfig) Route {
 			recipeConfig.SetNextRecipe(nextRecipe)
 		})
 
-		endpoint = AddMiddleware(endpoint, ValidateJSONMiddleware)
+		endpoint = AddMiddleware(endpoint, AuthorizeMiddleware, ValidateJSONMiddleware)
 
 		mux.Handle("/update-next-recipe", endpoint)
 	}


### PR DESCRIPTION
+ Added authentication middleware: it will always take the same amount of configured time to respond. This middleware has 3 parts: (1) setting up - making channels and getting the current time, (2) checks - running go routines that represent the logic checks (such as future whitelist checking) and sync responses through the setup channels, (3) response - sleeping the middleware until the configured response time period has elapsed, then responding based on the checks done in (2)
~ Updated primary web server to use HTTPS instead of HTTP. This is necessary because the Auth middleware is using http.request.BasicAuth() to get the user/password. Without HTTPS, the authorization header could be intercepted. In another future ticket, an http server will be added to redirect to the https server.