### PR TITLE
updated how static files are served

### DIFF
--- a/web/static/layout.html
+++ b/web/static/layout.html
@@ -1,10 +1,11 @@
 {{define "layout"}}
+<!DOCTYPE html>
 <html lang="en">
 <head>
 	<meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>{{template "title"}}</title>
-	<link rel="stylesheet" href="/stylesheets/output.css">
+	<link rel="stylesheet" href="/serveable/stylesheets/output.css">
     <link rel="shortcut icon" href="#">
 </head>
 <body class="bg-fft-bg">

--- a/web/static/serveable/scripts/main.js
+++ b/web/static/serveable/scripts/main.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+    console.log("main.js and dom loaded");
+})

--- a/web/static/serveable/stylesheets/output.css
+++ b/web/static/serveable/stylesheets/output.css
@@ -554,12 +554,67 @@ video {
   --tw-contain-style:  ;
 }
 
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
+.fixed {
+  position: fixed;
+}
+
+.col-span-1 {
+  grid-column: span 1 / span 1;
+}
+
 .m-8 {
   margin: 2rem;
 }
 
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
 .ml-4 {
   margin-left: 1rem;
+}
+
+.grid {
+  display: grid;
+}
+
+.h-10 {
+  height: 2.5rem;
 }
 
 .w-screen {
@@ -574,9 +629,29 @@ video {
   list-style-type: disc;
 }
 
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.content-center {
+  align-content: center;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
 .bg-fft-bg {
   --tw-bg-opacity: 1;
   background-color: rgb(57 54 61 / var(--tw-bg-opacity));
+}
+
+.pl-4 {
+  padding-left: 1rem;
+}
+
+.pr-2 {
+  padding-right: 0.5rem;
 }
 
 .text-center {
@@ -594,6 +669,11 @@ video {
 .text-7xl {
   font-size: 4.5rem;
   line-height: 1;
+}
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
 }
 
 .font-bold {
@@ -618,6 +698,22 @@ video {
   color: rgb(255 252 249 / var(--tw-text-opacity));
 }
 
+.text-gray-50 {
+  --tw-text-opacity: 1;
+  color: rgb(249 250 251 / var(--tw-text-opacity));
+}
+
 .fft-li-color {
   color: #95764c;
+}
+
+.hover\:bg-fuchsia-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(250 232 255 / var(--tw-bg-opacity));
+}
+
+@media (min-width: 768px) {
+  .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./static/**/*.html"],
+  content: ['./static/**/*.html'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
+ Added test javascript folder/file to prepare for custom components
~ Previously, only stylesheets were available to be served. Now, the web portion will have serveable and unserveable folders. Serveable resources are publicly available to be viewed. Unserveable resources are callable only behind authentication, but are not currently functional. Updated the static router to limit resource requests to /serveable, but also prevents users from accessing directories as resources
~ Special note regarding Layout.html: added the <!doctype html> back in. Apparently, this is necessary to activate no-quirks mode for browsers to use modern HTML/CSS behavior (https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode)